### PR TITLE
fix #11 - merge with other plugins' CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ exports.decorateConfig = (config) => {
     selectionColor: palette.highlightMed,
     borderColor: "#0000",
     css: `
+    ${config.css || ""}
 		.tab_text { color: ${palette.subtle} }
 		.tab_textActive { color: ${palette.text} }
     `,


### PR DESCRIPTION
### Issue Addressed:
#11 

### Description:
Plugins like hyper-statusline and hyper-tabs-enhanced will break since their CSS additions/changes  aren't being extended, but rather regressed.